### PR TITLE
Fix parsing of unsigned 64-bit constants

### DIFF
--- a/libropium/compiler/il.cpp
+++ b/libropium/compiler/il.cpp
@@ -769,7 +769,7 @@ bool _parse_il_instruction(Arch& arch, ILInstruction* instr, string& str){
 
 ILInstruction::ILInstruction(Arch& arch, string str){
     if( !_parse_il_instruction(arch, this, str)){
-        throw il_exception("Invald instruction string");
+        throw il_exception("Invalid instruction string");
     }
 }
 

--- a/libropium/compiler/il.cpp
+++ b/libropium/compiler/il.cpp
@@ -58,7 +58,7 @@ bool _parse_il_cst(Arch& arch, vector<cst_t>& args, string& str, int& idx){
     }
     
     try{
-        cst = std::stoll(s, 0, base);
+        cst = std::stoull(s, 0, base);
         // Check if cst is not too big
         if( arch.octets < 8 && (cst >= (ucst_t)((ucst_t)1<<(arch.bits)))){
             return false;


### PR DESCRIPTION
Hi there,

first of all, thanks for your awesome tool! I've been impressed by its speed and capabilities

One issue I've come across is that constants are parsed as signed values by using `stoll` (even though they are stored unsigned). This works fine in most cases, however, when a user specifies large unsigned constants (e.g., 0xffffffffffffffff == -1), ROPium fails instead of accepting the constant as expected (see the code snippets below): 

When using `stoll`:
```
(ropium)> find 0x1234(-1, 0xffffffffffffffff, rax)
[!] Invalid query: 0x1234(-1,0xffffffffffffffff,rax)
```

When using `stoull` instead, the result is as expected:
```
find 0x1234(-1, 0xffffffffffffffff, rax)

	0x0000000000026b72 (pop rdi; ret)
	0xffffffffffffffff
	0x0000000000027529 (pop rsi; ret)
	0xffffffffffffffff
	0x0000000000151841 (push rax; pop rbx; pop rbp; pop r12; ret)
	0xffffffffffffffff
	0xffffffffffffffff
	0x0000000000130006 (push rbx; adc al, 0x74; adc al, 0x5b; xor eax, eax; pop r12; pop rbp; ret)
	0xffffffffffffffff
	0x00000000000a2148 (mov rdx, r12; pop r12; pop r13; ret)
	0xffffffffffffffff
	0xffffffffffffffff
	0x000000000016b0e0 (ret)
	0x0000000000001234
	0x000000000016b0e0 (ret)
```

This pull request switches from `stoll` to `stoull` to support large unsigned constants and adds a few testcases to check for this case.

Cheers